### PR TITLE
[Requirements]version collision

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy
 scipy
-matplotlib
-scikit-image
+matplotlib==2.2.3
+scikit-image<0.15
 chumpy
 opencv-python
 absl-py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy
 scipy
 matplotlib==2.2.3
-scikit-image<0.15
+scikit-image==0.10.1
 chumpy
 opencv-python
 absl-py


### PR DESCRIPTION
Hi, I specify the package version to avoid installing the latest `matplotlib` and `scikit-learn` version which needs python3.5 or higher version.